### PR TITLE
Fixes for QGIS 3.x compatibility

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -4,7 +4,8 @@ description=Advanced geospatial data analysis engine
 about=Various spatial analysis tools
 category=Plugins
 version=0.1.0
-qgisMinimumVersion=2.99
+qgisMinimumVersion=3.0
+qgisMaximumVersion=3.99
 
 icon=icons/whiteboxtools.png
 tags=analysis,processing

--- a/whiteboxProvider.py
+++ b/whiteboxProvider.py
@@ -30,7 +30,7 @@ import os
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtCore import QCoreApplication
 
-from qgis.core import QgsProcessingProvider, QgsMessageLog
+from qgis.core import QgsProcessingProvider, QgsMessageLog, Qgis
 
 from processing.core.ProcessingConfig import ProcessingConfig, Setting
 
@@ -113,10 +113,10 @@ class WhiteboxProvider(QgsProcessingProvider):
                         self.algs.append(alg)
                     else:
                         QgsMessageLog.logMessage(self.tr('Could not load WhiteBox Tools algorithm from file: {}'.format(descriptionFile)),
-                                                 self.tr('Processing'), QgsMessageLog.CRITICAL)
+                                                 self.tr('Processing'), Qgis.Critical)
                 except Exception as e:
                     QgsMessageLog.logMessage(self.tr('Could not load WhiteBox Tools algorithm from file: {}\n{}'.format(descriptionFile, str(e))),
-                                             self.tr('Processing'), QgsMessageLog.CRITICAL)
+                                             self.tr('Processing'), Qgis.Critical)
 
         for a in self.algs:
             self.addAlgorithm(a)

--- a/whiteboxUtils.py
+++ b/whiteboxUtils.py
@@ -29,7 +29,7 @@ import os
 import re
 import subprocess
 
-from qgis.core import QgsMessageLog, QgsProcessingFeedback
+from qgis.core import QgsMessageLog, QgsProcessingFeedback, Qgis
 from processing.core.ProcessingLog import ProcessingLog
 from processing.core.ProcessingConfig import ProcessingConfig
 
@@ -76,7 +76,7 @@ def execute(commands, feedback=None):
         feedback = QgsProcessingFeedback()
 
     fused_command = ' '.join([str(c) for c in commands])
-    QgsMessageLog.logMessage(fused_command, 'Processing', QgsMessageLog.INFO)
+    QgsMessageLog.logMessage(fused_command, 'Processing', Qgis.Info)
     feedback.pushInfo('WhiteBox Tools command:')
     feedback.pushCommandInfo(fused_command)
     feedback.pushInfo('WhiteBox Tools command output:')
@@ -102,4 +102,4 @@ def execute(commands, feedback=None):
             pass
 
     if ProcessingConfig.getSetting(WHITEBOX_VERBOSE):
-        QgsMessageLog.logMessage('\n'.join(loglines), 'Processing', QgsMessageLog.INFO)
+        QgsMessageLog.logMessage('\n'.join(loglines), 'Processing', Qgis.Info)


### PR DESCRIPTION
Few fixes to make things work with a recent version of QGIS (e.g. 3.18)

- fix metadata
- fix message log calls